### PR TITLE
Handle expires_in sent as string

### DIFF
--- a/requests_auth/oauth2_tokens.py
+++ b/requests_auth/oauth2_tokens.py
@@ -65,7 +65,7 @@ class TokenMemoryCache:
         """
         expiry = datetime.datetime.utcnow().replace(
             tzinfo=datetime.timezone.utc
-        ) + datetime.timedelta(seconds=expires_in)
+        ) + datetime.timedelta(seconds=int(expires_in))
         self._add_token(key, token, expiry.timestamp())
 
     def _add_token(self, key: str, token: str, expiry: float):


### PR DESCRIPTION
Hi Colin,

We have a bug on line 68 => TypeError: unsupported type for timedelta seconds component: str

The casting to 'int' is not done so I propose to cast it explicitly to 'int'.
Works locally ;-)

Bram