### PR TITLE
Release 5.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: master
+    rev: 20.8b1
     hooks:
       - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow to provide a `requests.Session` instance for `*AuthorizationCode` flows (even `PKCE`), `*ClientCredentials` and `*ResourceOwnerPasswordCredentials` flows.
+- Explicit support for Python 3.9
+
+### Changed
+- Code now follow `black==20.8b1` formatting instead of the git master version.
 
 ## [5.1.0] - 2020-03-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.2.0] - 2020-10-14
 ### Added
 - Allow to provide a `requests.Session` instance for `*AuthorizationCode` flows (even `PKCE`), `*ClientCredentials` and `*ResourceOwnerPasswordCredentials` flows.
 - Explicit support for Python 3.9
@@ -128,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release
 
-[Unreleased]: https://github.com/Colin-b/requests_auth/compare/v5.1.0...HEAD
+[Unreleased]: https://github.com/Colin-b/requests_auth/compare/v5.2.0...HEAD
+[5.2.0]: https://github.com/Colin-b/requests_auth/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/Colin-b/requests_auth/compare/v5.0.2...v5.1.0
 [5.0.2]: https://github.com/Colin-b/requests_auth/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/Colin-b/requests_auth/compare/v5.0.0...v5.0.1

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use `requests_auth.OAuth2AuthorizationCode` to configure this kind of authentica
 import requests
 from requests_auth import OAuth2AuthorizationCode
 
-requests.get('http://www.example.com', auth=OAuth2AuthorizationCode('https://www.authorization.url', 'https://www.token.url'))
+requests.get('https://www.example.com', auth=OAuth2AuthorizationCode('https://www.authorization.url', 'https://www.token.url'))
 ```
 
 #### Parameters
@@ -108,7 +108,7 @@ from requests_auth import OktaAuthorizationCode
 
 
 okta = OktaAuthorizationCode(instance='testserver.okta-emea.com', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd')
-requests.get('http://www.example.com', auth=okta)
+requests.get('https://www.example.com', auth=okta)
 ```
 
 ###### Parameters
@@ -148,7 +148,7 @@ Use `requests_auth.OAuth2AuthorizationCodePKCE` to configure this kind of authen
 import requests
 from requests_auth import OAuth2AuthorizationCodePKCE
 
-requests.get('http://www.example.com', auth=OAuth2AuthorizationCodePKCE('https://www.authorization.url', 'https://www.token.url'))
+requests.get('https://www.example.com', auth=OAuth2AuthorizationCodePKCE('https://www.authorization.url', 'https://www.token.url'))
 ```
 
 #### Parameters 
@@ -196,7 +196,7 @@ from requests_auth import OktaAuthorizationCodePKCE
 
 
 okta = OktaAuthorizationCodePKCE(instance='testserver.okta-emea.com', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd')
-requests.get('http://www.example.com', auth=okta)
+requests.get('https://www.example.com', auth=okta)
 ```
 
 ###### Parameters
@@ -222,11 +222,11 @@ requests.get('http://www.example.com', auth=okta)
 Any other parameter will be put as query parameter in the authorization URL and as body parameters in the token URL.        
 
 Usual extra parameters are:
-        
+
 | Name            | Description                                                          |
 |:----------------|:---------------------------------------------------------------------|
 | `client_secret`        | If client is not authenticated with the authorization server     |
-| `nonce`        | Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details     |
+| `nonce`        | Refer to [OpenID ID Token specifications][3] for more details     |
 
 ### Resource Owner Password Credentials flow 
 
@@ -238,7 +238,7 @@ Use `requests_auth.OAuth2ResourceOwnerPasswordCredentials` to configure this kin
 import requests
 from requests_auth import OAuth2ResourceOwnerPasswordCredentials
 
-requests.get('http://www.example.com', auth=OAuth2ResourceOwnerPasswordCredentials('https://www.token.url', 'user name', 'user password'))
+requests.get('https://www.example.com', auth=OAuth2ResourceOwnerPasswordCredentials('https://www.token.url', 'user name', 'user password'))
 ```
 
 #### Parameters
@@ -266,7 +266,7 @@ Use `requests_auth.OAuth2ClientCredentials` to configure this kind of authentica
 import requests
 from requests_auth import OAuth2ClientCredentials
 
-requests.get('http://www.example.com', auth=OAuth2ClientCredentials('https://www.token.url', client_id='id', client_secret='secret'))
+requests.get('https://www.example.com', auth=OAuth2ClientCredentials('https://www.token.url', client_id='id', client_secret='secret'))
 ```
 
 #### Parameters
@@ -302,7 +302,7 @@ from requests_auth import OktaClientCredentials
 
 
 okta = OktaClientCredentials(instance='testserver.okta-emea.com', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd', client_secret="secret")
-requests.get('http://www.example.com', auth=okta)
+requests.get('https://www.example.com', auth=okta)
 ```
 
 ###### Parameters
@@ -331,7 +331,7 @@ Use `requests_auth.OAuth2Implicit` to configure this kind of authentication.
 import requests
 from requests_auth import OAuth2Implicit
 
-requests.get('http://www.example.com', auth=OAuth2Implicit('https://www.authorization.url'))
+requests.get('https://www.example.com', auth=OAuth2Implicit('https://www.authorization.url'))
 ```
 
 #### Parameters
@@ -377,7 +377,7 @@ from requests_auth import AzureActiveDirectoryImplicit
 
 
 aad = AzureActiveDirectoryImplicit(tenant_id='45239d18-c68c-4c47-8bdd-ce71ea1d50cd', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd')
-requests.get('http://www.example.com', auth=aad)
+requests.get('https://www.example.com', auth=aad)
 ```
 
 You can retrieve Microsoft Azure Active Directory application information thanks to the [application list on Azure portal](https://portal.azure.com/#blade/Microsoft_AAD_IAM/StartboardApplicationsMenuBlade/AllApps/menuId/).
@@ -419,7 +419,7 @@ from requests_auth import AzureActiveDirectoryImplicitIdToken
 
 
 aad = AzureActiveDirectoryImplicitIdToken(tenant_id='45239d18-c68c-4c47-8bdd-ce71ea1d50cd', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd')
-requests.get('http://www.example.com', auth=aad)
+requests.get('https://www.example.com', auth=aad)
 ```
 
 You can retrieve Microsoft Azure Active Directory application information thanks to the [application list on Azure portal](https://portal.azure.com/#blade/Microsoft_AAD_IAM/StartboardApplicationsMenuBlade/AllApps/menuId/).
@@ -461,7 +461,7 @@ from requests_auth import OktaImplicit
 
 
 okta = OktaImplicit(instance='testserver.okta-emea.com', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd')
-requests.get('http://www.example.com', auth=okta)
+requests.get('https://www.example.com', auth=okta)
 ```
 
 ###### Parameters
@@ -503,7 +503,7 @@ from requests_auth import OktaImplicitIdToken
 
 
 okta = OktaImplicitIdToken(instance='testserver.okta-emea.com', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd')
-requests.get('http://www.example.com', auth=okta)
+requests.get('https://www.example.com', auth=okta)
 ```
 
 ###### Parameters
@@ -557,7 +557,7 @@ You can send an API key inside the header of your request using `requests_auth.H
 import requests
 from requests_auth import HeaderApiKey
 
-requests.get('http://www.example.com', auth=HeaderApiKey('my_api_key'))
+requests.get('https://www.example.com', auth=HeaderApiKey('my_api_key'))
 ```
 
 ### Parameters
@@ -575,7 +575,7 @@ You can send an API key inside the query parameters of your request using `reque
 import requests
 from requests_auth import QueryApiKey
 
-requests.get('http://www.example.com', auth=QueryApiKey('my_api_key'))
+requests.get('https://www.example.com', auth=QueryApiKey('my_api_key'))
 ```
 
 ### Parameters
@@ -595,7 +595,7 @@ The only advantage of using this class instead of `requests` native support of b
 import requests
 from requests_auth import Basic
 
-requests.get('http://www.example.com', auth=Basic('username', 'password'))
+requests.get('https://www.example.com', auth=Basic('username', 'password'))
 ```
 
 ### Parameters
@@ -607,7 +607,7 @@ requests.get('http://www.example.com', auth=Basic('username', 'password'))
 
 ## NTLM
 
-Requires [requests-negotiate-sspi module][4] or [requests_ntlm module][5] depending on provided parameters.
+Requires [`requests-negotiate-sspi` module][4] or [`requests_ntlm` module][5] depending on provided parameters.
 
 You can use Windows authentication using `requests_auth.NTLM`.
 
@@ -615,19 +615,19 @@ You can use Windows authentication using `requests_auth.NTLM`.
 import requests
 from requests_auth import NTLM
 
-requests.get('http://www.example.com', auth=NTLM())
+requests.get('https://www.example.com', auth=NTLM())
 ```
 
 ### Parameters
 
 | Name                    | Description                    | Mandatory | Default value |
 |:------------------------|:-------------------------------|:----------|:--------------|
-| `username`              | User name.                     | Mandatory if requests_negotiate_sspi module is not installed. In such a case requests_ntlm module is mandatory. |               |
-| `password`              | User password.                 | Mandatory if requests_negotiate_sspi module is not installed. In such a case requests_ntlm module is mandatory. |               |
+| `username`              | User name.                     | Mandatory if `requests_negotiate_sspi` module is not installed. In such a case `requests_ntlm` module is mandatory. |               |
+| `password`              | User password.                 | Mandatory if `requests_negotiate_sspi` module is not installed. In such a case `requests_ntlm` module is mandatory. |               |
 
 ## Multiple authentication at once
 
-You can also use a combination of authentication using `+` as in the following sample:
+You can also use a combination of authentication using `+` or `&` as in the following sample:
 
 ```python
 import requests
@@ -635,12 +635,12 @@ from requests_auth import HeaderApiKey, OAuth2Implicit
 
 api_key = HeaderApiKey('my_api_key')
 oauth2 = OAuth2Implicit('https://www.example.com')
-requests.get('http://www.example.com', auth=api_key + oauth2)
+requests.get('https://www.example.com', auth=api_key + oauth2)
 ```
 
 ## Available pytest fixtures
 
-Testing the code using requests_auth authentication classes can be achieved using provided [`pytest`][6] fixtures.
+Testing the code using `requests_auth` authentication classes can be achieved using provided [`pytest`][6] fixtures.
 
 ### token_cache_mock
 
@@ -756,8 +756,8 @@ def test_something(browser_mock: BrowserMock):
 **Randall Degges**, Head of Evangelism, [Okta](https://developer.okta.com)
 
 [1]: https://pypi.python.org/pypi/requests "requests module"
-[2]: http://docs.python-requests.org/en/master/user/authentication/ "authentication parameter on requests module"
-[3]: http://openid.net/specs/openid-connect-core-1_0.html#IDToken "OpenID ID Token specifications"
+[2]: https://2.python-requests.org/en/master/user/authentication/ "authentication parameter on requests module"
+[3]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken "OpenID ID Token specifications"
 [4]: https://pypi.python.org/pypi/requests-negotiate-sspi "requests-negotiate-sspi module"
 [5]: https://pypi.python.org/pypi/requests_ntlm "requests_ntlm module"
 [6]: https://docs.pytest.org/en/latest/ "pytest module"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/requests_auth"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/requests_auth.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/requests_auth"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/requests_auth"><img alt="Number of tests" src="https://img.shields.io/badge/tests-242 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/requests_auth"><img alt="Number of tests" src="https://img.shields.io/badge/tests-249 passed-blue"></a>
 <a href="https://pypi.org/project/requests-auth/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/requests_auth"></a>
 </p>
 
@@ -79,6 +79,7 @@ requests.get('https://www.example.com', auth=OAuth2AuthorizationCode('https://ww
 | `code_field_name`       | Field name containing the code. | Optional | code |
 | `username`              | User name in case basic authentication should be used to retrieve token. | Optional |  |
 | `password`              | User password in case basic authentication should be used to retrieve token. | Optional |  |
+| `session`               | `requests.Session` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL and as body parameters in the token URL.        
 
@@ -129,6 +130,7 @@ requests.get('https://www.example.com', auth=okta)
 | `failure_display_time`  | In case received token is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
+| `session`               | `requests.Session` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL.        
 
@@ -167,6 +169,7 @@ requests.get('https://www.example.com', auth=OAuth2AuthorizationCodePKCE('https:
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | code |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
 | `code_field_name`       | Field name containing the code. | Optional | code |
+| `session`               | `requests.Session` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL and as body parameters in the token URL.        
 
@@ -218,6 +221,7 @@ requests.get('https://www.example.com', auth=okta)
 | `failure_display_time`  | In case received token is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
+| `session`               | `requests.Session` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL and as body parameters in the token URL.        
 
@@ -253,6 +257,7 @@ requests.get('https://www.example.com', auth=OAuth2ResourceOwnerPasswordCredenti
 | `header_value`     | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`            | Scope parameter sent to token URL as body. Can also be a list of scopes. | Optional |  |
 | `token_field_name` | Field name containing the token.             | Optional  | access_token  |
+| `session`          | `requests.Session` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as body parameter in the token URL.
 
@@ -274,13 +279,14 @@ requests.get('https://www.example.com', auth=OAuth2ClientCredentials('https://ww
 | Name               | Description                                  | Mandatory | Default value |
 |:-------------------|:---------------------------------------------|:----------|:--------------|
 | `token_url`        | OAuth 2 token URL.                           | Mandatory |               |
-| `client_id`         | Resource owner user name.                    | Mandatory |               |
-| `client_secret`         | Resource owner password.                     | Mandatory |               |
+| `client_id`        | Resource owner user name.                    | Mandatory |               |
+| `client_secret`    | Resource owner password.                     | Mandatory |               |
 | `timeout`          | Maximum amount of seconds to wait for a token to be received once requested. | Optional | 60            |
 | `header_name`      | Name of the header field used to send token. | Optional  | Authorization |
 | `header_value`     | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`            | Scope parameter sent to token URL as body. Can also be a list of scopes. | Optional |  |
 | `token_field_name` | Field name containing the token.             | Optional  | access_token  |
+| `session`          | `requests.Session` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as body parameter in the token URL.
 
@@ -318,6 +324,7 @@ requests.get('https://www.example.com', auth=okta)
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | openid |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `session`               | `requests.Session` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the token URL.        
 

--- a/requests_auth/version.py
+++ b/requests_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "5.1.0"
+__version__ = "5.2.0"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=[

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -7,6 +7,44 @@ from requests_auth.testing import BrowserMock, browser_mock, token_cache
 from tests.auth_helper import get_header, get_request
 
 
+def test_oauth2_authorization_code_flow_uses_provided_session(
+    token_cache, responses: RequestsMock, browser_mock: BrowserMock
+):
+    session = requests.Session()
+    session.headers.update({"x-test": "Test value"})
+    auth = requests_auth.OAuth2AuthorizationCode(
+        "http://provide_code", "http://provide_access_token", session=session
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(responses, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    request = get_request(responses, "http://provide_access_token/")
+    assert (
+        request.body
+        == "grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    assert request.headers["x-test"] == "Test value"
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
 def test_oauth2_authorization_code_flow_get_code_is_sent_in_authorization_header_by_default(
     token_cache, responses: RequestsMock, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code_okta.py
+++ b/tests/test_oauth2_authorization_code_okta.py
@@ -7,6 +7,48 @@ from requests_auth.testing import BrowserMock, browser_mock, token_cache
 from tests.auth_helper import get_header, get_request
 
 
+def test_oauth2_authorization_code_flow_uses_provided_session(
+    token_cache, responses: RequestsMock, browser_mock: BrowserMock
+):
+    session = requests.Session()
+    session.headers.update({"x-test": "Test value"})
+    auth = requests_auth.OktaAuthorizationCode(
+        "testserver.okta-emea.com",
+        "54239d18-c68c-4c47-8bdd-ce71ea1d50cd",
+        session=session,
+    )
+    tab = browser_mock.add_response(
+        opened_url="https://testserver.okta-emea.com/oauth2/default/v1/authorize?client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+    )
+    responses.add(
+        responses.POST,
+        "https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(responses, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    request = get_request(
+        responses, "https://testserver.okta-emea.com/oauth2/default/v1/token"
+    )
+    assert (
+        request.body
+        == "grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    assert request.headers["x-test"] == "Test value"
+    tab.assert_success(
+        "You are now authenticated on 5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b. You may close this tab."
+    )
+
+
 def test_oauth2_authorization_code_flow_get_code_is_sent_in_authorization_header_by_default(
     token_cache, responses: RequestsMock, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code_pkce.py
+++ b/tests/test_oauth2_authorization_code_pkce.py
@@ -7,6 +7,45 @@ from tests.auth_helper import get_header, get_request
 from requests_auth.testing import BrowserMock, browser_mock, token_cache
 
 
+def test_oauth2_pkce_flow_uses_provided_session(
+    token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock
+):
+    session = requests.Session()
+    session.headers.update({"x-test": "Test value"})
+    monkeypatch.setattr(requests_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = requests_auth.OAuth2AuthorizationCodePKCE(
+        "http://provide_code", "http://provide_access_token", session=session
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(responses, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    request = get_request(responses, "http://provide_access_token/")
+    assert (
+        request.body
+        == "code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    assert request.headers["x-test"] == "Test value"
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
 def test_oauth2_pkce_flow_get_code_is_sent_in_authorization_header_by_default(
     token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code_pkce_okta.py
+++ b/tests/test_oauth2_authorization_code_pkce_okta.py
@@ -7,6 +7,49 @@ from tests.auth_helper import get_header, get_request
 from requests_auth.testing import BrowserMock, browser_mock, token_cache
 
 
+def test_oauth2_pkce_flow_uses_provided_session(
+    token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock
+):
+    session = requests.Session()
+    session.headers.update({"x-test": "Test value"})
+    monkeypatch.setattr(requests_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = requests_auth.OktaAuthorizationCodePKCE(
+        "testserver.okta-emea.com",
+        "54239d18-c68c-4c47-8bdd-ce71ea1d50cd",
+        session=session,
+    )
+    tab = browser_mock.add_response(
+        opened_url="https://testserver.okta-emea.com/oauth2/default/v1/authorize?client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+    )
+    responses.add(
+        responses.POST,
+        "https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(responses, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    request = get_request(
+        responses, "https://testserver.okta-emea.com/oauth2/default/v1/token"
+    )
+    assert (
+        request.body
+        == "code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    assert request.headers["x-test"] == "Test value"
+    tab.assert_success(
+        "You are now authenticated on 5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b. You may close this tab."
+    )
+
+
 def test_oauth2_pkce_flow_get_code_is_sent_in_authorization_header_by_default(
     token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_client_credential.py
+++ b/tests/test_oauth2_client_credential.py
@@ -3,8 +3,38 @@ import pytest
 import requests
 
 import requests_auth
-from tests.auth_helper import get_header
+from tests.auth_helper import get_header, get_request
 from requests_auth.testing import token_cache
+
+
+def test_oauth2_client_credentials_flow_uses_provided_session(
+    token_cache, responses: RequestsMock
+):
+    session = requests.Session()
+    session.headers.update({"x-test": "Test value"})
+    auth = requests_auth.OAuth2ClientCredentials(
+        "http://provide_access_token",
+        client_id="test_user",
+        client_secret="test_pwd",
+        session=session,
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(responses, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    request = get_request(responses, "http://provide_access_token/")
+    assert request.headers["x-test"] == "Test value"
 
 
 def test_oauth2_client_credentials_flow_token_is_sent_in_authorization_header_by_default(

--- a/tests/test_oauth2_client_credential_okta.py
+++ b/tests/test_oauth2_client_credential_okta.py
@@ -1,8 +1,36 @@
+import requests
 from responses import RequestsMock
 
 import requests_auth
-from tests.auth_helper import get_header
+from tests.auth_helper import get_header, get_request
 from requests_auth.testing import token_cache
+
+
+def test_okta_client_credentials_flow_uses_provided_session(
+    token_cache, responses: RequestsMock
+):
+    session = requests.Session()
+    session.headers.update({"x-test": "Test value"})
+    auth = requests_auth.OktaClientCredentials(
+        "test_okta", client_id="test_user", client_secret="test_pwd", session=session
+    )
+    responses.add(
+        responses.POST,
+        "https://test_okta/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(responses, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    request = get_request(responses, "https://test_okta/oauth2/default/v1/token")
+    assert request.headers["x-test"] == "Test value"
 
 
 def test_okta_client_credentials_flow_token_is_sent_in_authorization_header_by_default(


### PR DESCRIPTION
### Added
- Allow to provide a `requests.Session` instance for `*AuthorizationCode` flows (even `PKCE`), `*ClientCredentials` and `*ResourceOwnerPasswordCredentials` flows.
- Explicit support for Python 3.9

### Changed
- Code now follow `black==20.8b1` formatting instead of the git master version.