### PR TITLE
Support for refresh tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for refresh tokens in the Resource Owner Password Credentials flow and Authorization Code (with and without PKCE) flows.
 
 ## [5.2.0] - 2020-10-14
 ### Added

--- a/requests_auth/authentication.py
+++ b/requests_auth/authentication.py
@@ -229,8 +229,7 @@ class OAuth2ResourceOwnerPasswordCredentials(requests.auth.AuthBase, SupportMult
             self.timeout,
             self.session
         )
-        # Handle both Access and Bearer tokens
-        return (self.state, token, expires_in, refresh_token) if expires_in else (self.state, token)
+        return self.state, token, expires_in, refresh_token
 
 
 class OAuth2ClientCredentials(requests.auth.AuthBase, SupportMultiAuth):
@@ -470,8 +469,7 @@ class OAuth2AuthorizationCode(requests.auth.AuthBase, SupportMultiAuth, BrowserA
             self.timeout,
             self.session
         )
-        # Handle both Access and Bearer tokens
-        return (self.state, token, expires_in, refresh_token) if expires_in else (self.state, token)
+        return self.state, token, expires_in, refresh_token
 
 
 class OAuth2AuthorizationCodePKCE(
@@ -644,8 +642,7 @@ class OAuth2AuthorizationCodePKCE(
             self.timeout,
             self.session
         )
-        # Handle both Access and Bearer tokens
-        return (self.state, token, expires_in, refresh_token) if expires_in else (self.state, token)
+        return self.state, token, expires_in, refresh_token
 
 
     @staticmethod

--- a/tests/test_json_token_file_cache.py
+++ b/tests/test_json_token_file_cache.py
@@ -82,3 +82,15 @@ def test_missing_token_function(token_cache):
     token = jwt.encode({"exp": expiry_in_1_hour}, "secret").decode("unicode_escape")
     retrieved_token = token_cache.get_token("key1", lambda: ("key1", token))
     assert retrieved_token == token
+
+
+def test_token_without_refresh_token(token_cache):
+    expiry_in_1_hour = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+    # add token without refresh token
+    token = jwt.encode({"exp": expiry_in_1_hour}, "secret").decode("unicode_escape")
+    token_cache.tokens['key1'] = token, expiry_in_1_hour.replace(tzinfo=datetime.timezone.utc).timestamp()
+    token_cache._save_tokens()
+
+    # try to retrieve it
+    retrieved_token = token_cache.get_token("key1")
+    assert token == retrieved_token

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -145,6 +145,137 @@ def test_refresh_token(token_cache, responses: RequestsMock, browser_mock: Brows
     )
 
 
+def test_refresh_token_invalid(token_cache, responses: RequestsMock, browser_mock: BrowserMock):
+    auth = requests_auth.OAuth2AuthorizationCode(
+        "http://provide_code", "http://provide_access_token"
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": "0",
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({
+                "grant_type": "authorization_code",
+                "redirect_uri": "http://localhost:5000/",
+                "response_type": "code",
+                "code": "SplxlOBeZQQYbYS6WxSbIA"
+            })
+        ]
+    )
+    assert (
+            get_header(responses, auth).get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    assert (
+            get_request(responses, "http://provide_access_token/").body
+            == "grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+    # response for refresh token grant
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={"error": "invalid_request"},
+        status=400,
+        match=[
+            urlencoded_params_matcher(
+                {"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
+        ]
+    )
+
+    # initialize tab again because a thread can only be started once
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+
+    # if refreshing the token fails, fallback to requesting a new token
+    response = requests.get("http://authorized_only", auth=auth)
+    assert (
+            response.request.headers.get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
+def test_refresh_token_access_token_not_expired(token_cache, responses: RequestsMock, browser_mock: BrowserMock):
+    auth = requests_auth.OAuth2AuthorizationCode(
+        "http://provide_code", "http://provide_access_token"
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({
+                "grant_type": "authorization_code",
+                "redirect_uri": "http://localhost:5000/",
+                "response_type": "code",
+                "code": "SplxlOBeZQQYbYS6WxSbIA"
+            })
+        ]
+    )
+    assert (
+            get_header(responses, auth).get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    assert (
+            get_request(responses, "http://provide_access_token/").body
+            == "grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+    # response for refresh token grant
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "rVR7Syg5bjZtZYjbZIW",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher(
+                {"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
+        ]
+    )
+
+    # expect Bearer token to remain the same
+    assert (
+            get_header(responses, auth).get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    # refresh request is not used
+    responses.assert_all_requests_are_fired = False
+
 def test_empty_token_is_invalid(
     token_cache, responses: RequestsMock, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -141,7 +141,7 @@ def test_refresh_token(token_cache, responses: RequestsMock, browser_mock: Brows
     )
     assert (
             get_request(responses, "http://provide_access_token/").body
-            == "grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA&response_type=code"
+            == "grant_type=refresh_token&response_type=code&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA"
     )
 
 

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -251,30 +251,10 @@ def test_refresh_token_access_token_not_expired(token_cache, responses: Requests
     tab.assert_success(
         "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
     )
-    # response for refresh token grant
-    responses.add(
-        responses.POST,
-        "http://provide_access_token",
-        json={
-            "access_token": "rVR7Syg5bjZtZYjbZIW",
-            "token_type": "example",
-            "expires_in": 3600,
-            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
-            "example_parameter": "example_value",
-        },
-        match=[
-            urlencoded_params_matcher(
-                {"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
-        ]
-    )
 
     # expect Bearer token to remain the same
-    assert (
-            get_header(responses, auth).get("Authorization")
-            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
-    )
-    # refresh request is not used
-    responses.assert_all_requests_are_fired = False
+    response = requests.get("http://authorized_only", auth=auth)
+    assert (response.request.headers.get("Authorization") == "Bearer 2YotnFZFEjr1zCsicMWpAA")
 
 def test_empty_token_is_invalid(
     token_cache, responses: RequestsMock, browser_mock: BrowserMock

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -1,4 +1,4 @@
-from responses import RequestsMock
+from responses import RequestsMock, urlencoded_params_matcher
 import pytest
 import requests
 
@@ -76,6 +76,72 @@ def test_oauth2_authorization_code_flow_get_code_is_sent_in_authorization_header
     )
     tab.assert_success(
         "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
+def test_refresh_token(token_cache, responses: RequestsMock, browser_mock: BrowserMock):
+    auth = requests_auth.OAuth2AuthorizationCode(
+        "http://provide_code", "http://provide_access_token"
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 1,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({
+                "grant_type": "authorization_code",
+                "redirect_uri": "http://localhost:5000/",
+                "response_type": "code",
+                "code": "SplxlOBeZQQYbYS6WxSbIA"
+            })
+        ]
+    )
+    assert (
+            get_header(responses, auth).get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    assert (
+            get_request(responses, "http://provide_access_token/").body
+            == "grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+    # response for refresh token grant
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "rVR7Syg5bjZtZYjbZIW",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher(
+                {"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
+        ]
+    )
+
+    response = requests.get("http://authorized_only", auth=auth)
+    assert (
+            response.request.headers.get("Authorization")
+            == "Bearer rVR7Syg5bjZtZYjbZIW"
+    )
+    assert (
+            get_request(responses, "http://provide_access_token/").body
+            == "grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA&response_type=code"
     )
 
 

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -93,7 +93,7 @@ def test_refresh_token(token_cache, responses: RequestsMock, browser_mock: Brows
         json={
             "access_token": "2YotnFZFEjr1zCsicMWpAA",
             "token_type": "example",
-            "expires_in": 1,
+            "expires_in": "0",
             "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
             "example_parameter": "example_value",
         },

--- a/tests/test_oauth2_authorization_code_pkce.py
+++ b/tests/test_oauth2_authorization_code_pkce.py
@@ -179,7 +179,7 @@ def test_refresh_token(token_cache, responses: RequestsMock, monkeypatch, browse
     )
     assert (
             get_request(responses, "http://provide_access_token/").body
-            == "grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA&response_type=code"
+            == "grant_type=refresh_token&response_type=code&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA"
     )
 
 

--- a/tests/test_oauth2_authorization_code_pkce.py
+++ b/tests/test_oauth2_authorization_code_pkce.py
@@ -292,27 +292,10 @@ def test_refresh_token_access_token_not_expired(token_cache, responses: Requests
     tab.assert_success(
         "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
     )
-    # response for refresh token grant
-    responses.add(
-        responses.POST,
-        "http://provide_access_token",
-        json={
-            "access_token": "rVR7Syg5bjZtZYjbZIW",
-            "token_type": "example",
-            "expires_in": 3600,
-            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
-            "example_parameter": "example_value",
-        },
-        match=[
-            urlencoded_params_matcher({"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
-        ]
-    )
 
     # expect Bearer token to remain the same
-    assert (get_header(responses, auth).get("Authorization") == "Bearer 2YotnFZFEjr1zCsicMWpAA")
-
-    # refresh request is not used
-    responses.assert_all_requests_are_fired = False
+    response = requests.get("http://authorized_only", auth=auth)
+    assert (response.request.headers.get("Authorization") == "Bearer 2YotnFZFEjr1zCsicMWpAA")
 
 
 def test_nonce_is_sent_if_provided_in_authorization_url(

--- a/tests/test_oauth2_authorization_code_pkce.py
+++ b/tests/test_oauth2_authorization_code_pkce.py
@@ -1,4 +1,4 @@
-from responses import RequestsMock
+from responses import RequestsMock, urlencoded_params_matcher
 import pytest
 import requests
 
@@ -114,6 +114,74 @@ def test_expires_in_sent_as_str(
     tab.assert_success(
         "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
     )
+
+
+def test_refresh_token(token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock):
+    monkeypatch.setattr(requests_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = requests_auth.OAuth2AuthorizationCodePKCE(
+        "http://provide_code", "http://provide_access_token"
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 1,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({
+                "grant_type": "authorization_code",
+                "code_verifier": "MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx",
+                "redirect_uri": "http://localhost:5000/",
+                "response_type": "code",
+                "code": "SplxlOBeZQQYbYS6WxSbIA"
+            })
+        ]
+    )
+    assert (
+        get_header(responses, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    assert (
+        get_request(responses, "http://provide_access_token/").body
+        == "code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+    # response for refresh token grant
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "rVR7Syg5bjZtZYjbZIW",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
+        ]
+    )
+
+    response = requests.get("http://authorized_only", auth=auth)
+    assert (
+            response.request.headers.get("Authorization")
+            == "Bearer rVR7Syg5bjZtZYjbZIW"
+    )
+    assert (
+            get_request(responses, "http://provide_access_token/").body
+            == "grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA&response_type=code"
+    )
+
 
 
 def test_nonce_is_sent_if_provided_in_authorization_url(

--- a/tests/test_oauth2_authorization_code_pkce.py
+++ b/tests/test_oauth2_authorization_code_pkce.py
@@ -131,7 +131,7 @@ def test_refresh_token(token_cache, responses: RequestsMock, monkeypatch, browse
         json={
             "access_token": "2YotnFZFEjr1zCsicMWpAA",
             "token_type": "example",
-            "expires_in": 1,
+            "expires_in": "0",
             "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
             "example_parameter": "example_value",
         },

--- a/tests/test_oauth2_authorization_code_pkce.py
+++ b/tests/test_oauth2_authorization_code_pkce.py
@@ -183,6 +183,137 @@ def test_refresh_token(token_cache, responses: RequestsMock, monkeypatch, browse
     )
 
 
+def test_refresh_token_invalid(token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock):
+    monkeypatch.setattr(requests_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = requests_auth.OAuth2AuthorizationCodePKCE(
+        "http://provide_code", "http://provide_access_token"
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": "0",
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({
+                "grant_type": "authorization_code",
+                "code_verifier": "MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx",
+                "redirect_uri": "http://localhost:5000/",
+                "response_type": "code",
+                "code": "SplxlOBeZQQYbYS6WxSbIA"
+            })
+        ]
+    )
+    assert (
+            get_header(responses, auth).get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    assert (
+            get_request(responses, "http://provide_access_token/").body
+            == "code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+    # response for refresh token grant
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={"error": "invalid_request"},
+        status=400,
+        match=[
+            urlencoded_params_matcher({"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
+        ]
+    )
+
+    # initialize tab again because a thread can only be started once
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+
+    # if refreshing the token fails, fallback to requesting a new token
+    response = requests.get("http://authorized_only", auth=auth)
+    assert (
+            response.request.headers.get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
+def test_refresh_token_access_token_not_expired(token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock):
+    monkeypatch.setattr(requests_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = requests_auth.OAuth2AuthorizationCodePKCE(
+        "http://provide_code", "http://provide_access_token"
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({
+                "grant_type": "authorization_code",
+                "code_verifier": "MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx",
+                "redirect_uri": "http://localhost:5000/",
+                "response_type": "code",
+                "code": "SplxlOBeZQQYbYS6WxSbIA"
+            })
+        ]
+    )
+    assert (
+            get_header(responses, auth).get("Authorization")
+            == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    assert (
+            get_request(responses, "http://provide_access_token/").body
+            == "code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+    # response for refresh token grant
+    responses.add(
+        responses.POST,
+        "http://provide_access_token",
+        json={
+            "access_token": "rVR7Syg5bjZtZYjbZIW",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match=[
+            urlencoded_params_matcher({"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA", "response_type": "code"})
+        ]
+    )
+
+    # expect Bearer token to remain the same
+    assert (get_header(responses, auth).get("Authorization") == "Bearer 2YotnFZFEjr1zCsicMWpAA")
+
+    # refresh request is not used
+    responses.assert_all_requests_are_fired = False
+
 
 def test_nonce_is_sent_if_provided_in_authorization_url(
     token_cache, responses: RequestsMock, monkeypatch, browser_mock: BrowserMock

--- a/tests/test_oauth2_resource_owner_password.py
+++ b/tests/test_oauth2_resource_owner_password.py
@@ -101,7 +101,7 @@ def test_refresh_token(token_cache, responses: RequestsMock):
         json={
             "access_token": "2YotnFZFEjr1zCsicMWpAA",
             "token_type": "example",
-            "expires_in": 1,  # let the token expire immediately after the first request
+            "expires_in": "0",  # let the token expire immediately after the first request
             "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
             "example_parameter": "example_value",
         },
@@ -157,7 +157,7 @@ def test_refresh_token_invalid(token_cache, responses: RequestsMock):
         json={
             "access_token": "2YotnFZFEjr1zCsicMWpAA",
             "token_type": "example",
-            "expires_in": 1,  # let the token expire immediately after the first request
+            "expires_in": "0",  # let the token expire immediately after the first request
             "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
             "example_parameter": "example_value",
         },

--- a/tests/test_oauth2_resource_owner_password.py
+++ b/tests/test_oauth2_resource_owner_password.py
@@ -223,27 +223,9 @@ def test_refresh_token_access_token_not_expired(token_cache, responses: Requests
             == "grant_type=password&username=test_user&password=test_pwd"
     )
 
-    # response for refresh token grant
-    responses.add(
-        responses.POST,
-        "http://provide_access_token",
-        json={
-            "access_token": "rVR7Syg5bjZtZYjbZIW",
-            "token_type": "example",
-            "expires_in": 3600,
-            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
-            "example_parameter": "example_value",
-        },
-        match=[
-            urlencoded_params_matcher({"grant_type": "refresh_token", "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA"})
-        ]
-    )
-
     # expect Bearer token to remain the same
-    assert (get_header(responses, auth).get("Authorization") == "Bearer 2YotnFZFEjr1zCsicMWpAA")
-
-    # refresh request is not used
-    responses.assert_all_requests_are_fired = False
+    response = requests.get("http://authorized_only", auth=auth)
+    assert (response.request.headers.get("Authorization") == "Bearer 2YotnFZFEjr1zCsicMWpAA")
 
 
 def test_scope_is_sent_as_is_when_provided_as_str(token_cache, responses: RequestsMock):


### PR DESCRIPTION
#13 - Added support for refresh tokens in the authorization code (with/without PKCE) and the resource owner password credentials flow. 
~~#60 - Added `early_expire` parameter to allow refreshing tokens before they actually expire. The default is set to 5 seconds.~~