### PR TITLE
Enable domain name to be provided to authentication.BrowserAuth

### DIFF
--- a/requests_auth/authentication.py
+++ b/requests_auth/authentication.py
@@ -114,9 +114,9 @@ class BrowserAuth:
         """
         redirect_uri_endpoint = kwargs.pop("redirect_uri_endpoint", None) or ""
         self.redirect_uri_port = int(kwargs.pop("redirect_uri_port", None) or 5000)
-        self.redirect_uri_domain = kwargs.pop("redirect_uri_domain", None) or "http://localhost"
+        self.redirect_uri_domain = kwargs.pop("redirect_uri_domain", None) or "localhost"
         self.redirect_uri = (
-            f"{self.redirect_uri_domain}:{self.redirect_uri_port}/{redirect_uri_endpoint}"
+            f"http://{self.redirect_uri_domain}:{self.redirect_uri_port}/{redirect_uri_endpoint}"
         )
 
         # Time is expressed in seconds
@@ -343,10 +343,10 @@ class OAuth2AuthorizationCode(requests.auth.AuthBase, SupportMultiAuth, BrowserA
         :param authorization_url: OAuth 2 authorization URL.
         :param token_url: OAuth 2 token URL.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 code will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a code or a token to be received once requested.
@@ -516,10 +516,10 @@ class OAuth2AuthorizationCodePKCE(
         :param authorization_url: OAuth 2 authorization URL.
         :param token_url: OAuth 2 token URL.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 code will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a code or a token to be received once requested.
@@ -734,10 +734,10 @@ class OAuth2Implicit(requests.auth.AuthBase, SupportMultiAuth, BrowserAuth):
         Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
         reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -841,10 +841,10 @@ class AzureActiveDirectoryImplicit(OAuth2Implicit):
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -894,10 +894,10 @@ class AzureActiveDirectoryImplicitIdToken(OAuth2Implicit):
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -954,10 +954,10 @@ class OktaImplicit(OAuth2Implicit):
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request ['openid', 'profile', 'email'] by default.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -1013,10 +1013,10 @@ class OktaImplicitIdToken(OAuth2Implicit):
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request ['openid', 'profile', 'email'] by default.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -1074,10 +1074,10 @@ class OktaAuthorizationCode(OAuth2AuthorizationCode):
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request 'openid' by default.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -1136,10 +1136,10 @@ class OktaAuthorizationCodePKCE(OAuth2AuthorizationCodePKCE):
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request 'openid' by default.
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
          When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        http://<redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.

--- a/requests_auth/authentication.py
+++ b/requests_auth/authentication.py
@@ -113,8 +113,9 @@ class BrowserAuth:
         """
         redirect_uri_endpoint = kwargs.pop("redirect_uri_endpoint", None) or ""
         self.redirect_uri_port = int(kwargs.pop("redirect_uri_port", None) or 5000)
+        self.redirect_uri_domain = kwargs.pop("redirect_uri_domain", None) or "http://localhost"
         self.redirect_uri = (
-            f"http://localhost:{self.redirect_uri_port}/{redirect_uri_endpoint}"
+            f"{self.redirect_uri_domain}:{self.redirect_uri_port}/{redirect_uri_endpoint}"
         )
 
         # Time is expressed in seconds

--- a/requests_auth/authentication.py
+++ b/requests_auth/authentication.py
@@ -99,7 +99,8 @@ class BrowserAuth:
     def __init__(self, kwargs):
         """
         :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. When not provided will default to http://localhost
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+        When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
         <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 code will be started.
@@ -343,8 +344,11 @@ class OAuth2AuthorizationCode(requests.auth.AuthBase, SupportMultiAuth, BrowserA
         """
         :param authorization_url: OAuth 2 authorization URL.
         :param token_url: OAuth 2 token URL.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 code will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a code or a token to be received once requested.
@@ -513,8 +517,11 @@ class OAuth2AuthorizationCodePKCE(
         """
         :param authorization_url: OAuth 2 authorization URL.
         :param token_url: OAuth 2 token URL.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 code will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a code or a token to be received once requested.
@@ -728,8 +735,11 @@ class OAuth2Implicit(requests.auth.AuthBase, SupportMultiAuth, BrowserAuth):
         :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
         Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
         reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -832,8 +842,11 @@ class AzureActiveDirectoryImplicit(OAuth2Implicit):
         reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -882,8 +895,11 @@ class AzureActiveDirectoryImplicitIdToken(OAuth2Implicit):
         reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -939,8 +955,11 @@ class OktaImplicit(OAuth2Implicit):
         default by default.
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request ['openid', 'profile', 'email'] by default.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -995,8 +1014,11 @@ class OktaImplicitIdToken(OAuth2Implicit):
         default by default.
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request ['openid', 'profile', 'email'] by default.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -1053,8 +1075,11 @@ class OktaAuthorizationCode(OAuth2AuthorizationCode):
         default by default.
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request 'openid' by default.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
@@ -1112,8 +1137,11 @@ class OktaAuthorizationCodePKCE(OAuth2AuthorizationCodePKCE):
         default by default.
         :param scope: Scope parameter sent in query. Can also be a list of scopes.
         Request 'openid' by default.
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
+         When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.

--- a/requests_auth/authentication.py
+++ b/requests_auth/authentication.py
@@ -98,8 +98,10 @@ class SupportMultiAuth:
 class BrowserAuth:
     def __init__(self, kwargs):
         """
+        :param redirect_uri_domain: Custom domain name that will be used in the following way:
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. When not provided will default to http://localhost
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
-        http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
+        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 code will be started.
         Listen on port 5000 by default.
         :param timeout: Maximum amount of seconds to wait for a code or a token to be received once requested.

--- a/requests_auth/authentication.py
+++ b/requests_auth/authentication.py
@@ -98,9 +98,7 @@ class SupportMultiAuth:
 class BrowserAuth:
     def __init__(self, kwargs):
         """
-        :param redirect_uri_domain: Custom domain name that will be used in the following way:
-        <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. 
-        When not provided will default to http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>
+        :param redirect_uri_domain: FQDN for localhost. localhost by default.
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
         <redirect_uri_domain>:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 code will be started.


### PR DESCRIPTION
Hi Colin,

Please review the change and comment, I'll update the documentation add test cases when I get home.

The change is to allow domain name to be passed as an optional keyword arg. We have our OKTA setup in such a way that our company domain name is required even for localhost such as http(s)://localhost.somecompany.com:<port>/<redirect-uri

Thanks